### PR TITLE
Update OPB links and link text with the latest conventions

### DIFF
--- a/opf-aov-pub.html
+++ b/opf-aov-pub.html
@@ -1235,8 +1235,8 @@
             href="#organization-model-japan"></a> for one of the concrete
             example of [=Profile Annotation=]. Also refer to
             <a
-            href="https://docs.originator-profile.org/en/opb/pa-guide/">Originator
-            Profile Blueprints: PA Implementation Guidelines</a> for more
+            href="https://docs.originator-profile.org/en/opb/pa-model/">Originator
+            Profile Blueprints: PA Data Models</a> for more
             information on implementing profile annotations in general.
           </p>
 
@@ -1503,8 +1503,8 @@
           </p>
           <p>
             Please refer [[Originator Profile Blueprints]]: <a
-            href="https://docs.originator-profile.org/en/opb/pa-guide/existence/">
-            Existence Certificate in Japan Implementation Guidelines</a> for
+            href="https://docs.originator-profile.org/en/opb/pa-model/existence/">
+            Existence Certificate in Japan</a> for
             current implementation details.
           </p>
         </section>


### PR DESCRIPTION
* Deprecate the term "Implementation Guidelines"
* Replace "guide" with "model" in link URLs accordingly

ref https://github.com/originator-profile/docs.originator-profile.org/issues/517